### PR TITLE
add support for other palettes with `ly_image`

### DIFF
--- a/R/fig_layer.R
+++ b/R/fig_layer.R
@@ -46,7 +46,7 @@ add_layer <- function(obj, spec, dat, lname, lgroup) {
 
   if(glyph == "Image") {
     c_id <- gen_id(obj, "ColorMapper")
-    cmap <- color_mapper_model(c_id)
+    cmap <- color_mapper_model(c_id, palette = dat$palette)
     glyph_attrs$color_mapper <- cmap$ref
     obj$model[[c_id]] <- cmap$model
   }
@@ -113,8 +113,8 @@ glyph_renderer_model <- function(id, data_ref, glyph_ref, ns_glyph_ref) {
   res
 }
 
-color_mapper_model <- function(id) {
+color_mapper_model <- function(id, palette = c("#9e0142", "#d53e4f", "#f46d43", "#fdae61", "#fee08b", "#ffffbf", "#e6f598", "#abdda4", "#66c2a5", "#3288bd", "#5e4fa2")) {
   res <- base_model_object("LinearColorMapper", id)
-  res$model$attributes$palette <- c("#9e0142", "#d53e4f", "#f46d43", "#fdae61", "#fee08b", "#ffffbf", "#e6f598", "#abdda4", "#66c2a5", "#3288bd", "#5e4fa2")
+  res$model$attributes$palette <- palette
   res
 }

--- a/R/layer_image.R
+++ b/R/layer_image.R
@@ -42,7 +42,7 @@ ly_image <- function(fig, z, rows, cols, x = 0, y = 0, dw = 1, dh = 1,
   #   plus added check for length 1
   if( is.character(palette) && length(palette) == 1 ) {
     if(valid_color(palette)) {
-      col <- palette
+      stop("'palette' specified in ly_image is a single color; please supply a vector of colors or name of a bokeh palette - see here: http://bokeh.pydata.org/en/latest/docs/reference/palettes.html", call. = FALSE)
     } else {
       if(!palette %in% bk_palette_names){
         stop("'palette' specified in ly_image is not a valid color name or palette - see here: http://bokeh.pydata.org/en/latest/docs/reference/palettes.html", call. = FALSE)

--- a/R/layer_image.R
+++ b/R/layer_image.R
@@ -10,7 +10,7 @@
 #' @param y lower left y coordinates
 #' @param dw image width distances
 #' @param dh image height distances
-#' @param palette palette to use for color-mapping
+#' @param palette name of color palette to use for color ramp (see \href{http://bokeh.pydata.org/en/latest/docs/reference/palettes.html}{here} for acceptable values)
 #' @param dilate logical - whether to dilate pixel distance computations when drawing
 #' @template par-lnamegroup
 #' @example man-roxygen/ex-image.R
@@ -35,6 +35,19 @@ ly_image <- function(fig, z, rows, cols, x = 0, y = 0, dw = 1, dh = 1,
     cols <- nrow(z)
     rows <- ncol(z)
     z <- array(z)
+  }
+  
+  # palette checker / transformer from layer_hexbin minus function
+  if(is.character(palette)) {
+    if(valid_color(palette)) {
+      col <- palette
+    } else {
+      if(!palette %in% bk_palette_names){
+        stop("'palette' specified in ly_image is not a valid color name or palette - see here: http://bokeh.pydata.org/en/latest/docs/reference/palettes.html", call. = FALSE)
+      } else {
+        palette <- bk_palettes[[palette]]
+      }
+    }
   }
 
   make_glyph(fig, type = "image", lname = lname, lgroup = lgroup,

--- a/R/layer_image.R
+++ b/R/layer_image.R
@@ -37,8 +37,10 @@ ly_image <- function(fig, z, rows, cols, x = 0, y = 0, dw = 1, dh = 1,
     z <- array(z)
   }
   
+  # really ugly nested if else
   # palette checker / transformer from layer_hexbin minus function
-  if(is.character(palette)) {
+  #   plus added check for length 1
+  if( is.character(palette) && length(palette) == 1 ) {
     if(valid_color(palette)) {
       col <- palette
     } else {
@@ -48,6 +50,13 @@ ly_image <- function(fig, z, rows, cols, x = 0, y = 0, dw = 1, dh = 1,
         palette <- bk_palettes[[palette]]
       }
     }
+  } else if( is.character(palette) && length(palette) > 1 ) {
+    # check for valid colors in the palette
+    if(!all(sapply(palette,valid_color))){
+      stop("'palette' specified in ly_image is not a valid color name or palette - see here: http://bokeh.pydata.org/en/latest/docs/reference/palettes.html", call. = FALSE)    
+    }
+  } else {
+    stop("'palette' specified in ly_image is not a valid color name or palette - see here: http://bokeh.pydata.org/en/latest/docs/reference/palettes.html", call. = FALSE)    
   }
 
   make_glyph(fig, type = "image", lname = lname, lgroup = lgroup,

--- a/R/layer_image.R
+++ b/R/layer_image.R
@@ -52,7 +52,7 @@ ly_image <- function(fig, z, rows, cols, x = 0, y = 0, dw = 1, dh = 1,
     }
   } else if( is.character(palette) && length(palette) > 1 ) {
     # check for valid colors in the palette
-    if(!all(sapply(palette,valid_color))){
+    if(!valid_color(palette)){
       stop("'palette' specified in ly_image is not a valid color name or palette - see here: http://bokeh.pydata.org/en/latest/docs/reference/palettes.html", call. = FALSE)    
     }
   } else {

--- a/R/layer_image.R
+++ b/R/layer_image.R
@@ -17,7 +17,7 @@
 #' @family layer functions
 #' @export
 ly_image <- function(fig, z, rows, cols, x = 0, y = 0, dw = 1, dh = 1,
-  palette = "Spectral-10", dilate = FALSE,
+  palette = "Spectral10", dilate = FALSE,
   lname = NULL, lgroup = NULL) {
 
   validate_fig(fig, "ly_image")

--- a/tests/testthat/test-figures.R
+++ b/tests/testthat/test-figures.R
@@ -128,7 +128,39 @@ test_that("examples", {
     ly_image(volcano) %>%
     ly_contour(volcano)
   print_model_json(p, file = "/dev/null")
+  
+  # check palette with ly_image
+  #  should reject a single color
+   expect_error(
+     ly_image(
+       figure( width = 700, height = 400 )
+       ,volcano
+       ,palette = "#FF00FF" 
+     )
+   )
+  #  should accept no palette and use default
+  p <- ly_image(
+    figure( width = 700, height = 400 )
+    ,volcano
+  )
+  print_model_json(p, file = "/dev/null") 
+  #  should accept a Bokeh palette name
+  p <- ly_image(
+    figure( width = 700, height = 400 )
+    ,volcano
+    ,palette = "Greys9"
+  )
+  print_model_json(p, file = "/dev/null") 
+  #  should accept a vector of colors
+  p <- ly_image(
+    figure( width = 700, height = 400 )
+    ,volcano
+    ,palette = blues9
+  )
+  print_model_json(p, file = "/dev/null")   
 
+  
+  
   url <- c("http://bokeh.pydata.org/en/latest/_static/bokeh-transparent.png",
     "http://developer.r-project.org/Logo/Rlogo-4.png")
 


### PR DESCRIPTION
addresses #33 but not sure that this fits with the style and model you have built into `rbokeh`.  Questions:

1.  in these [lines](https://github.com/timelyportfolio/rBokeh/blob/fix/image-palette/R/make_glyph.R#L117-L137) the palette still resides in `data` and `args$palette = "palette"` is in `args`.  I think the `palette` vector should also be moved to `args$palette` and out of `data`, but this still works.

2. in these [lines](https://github.com/timelyportfolio/rBokeh/blob/fix/image-palette/R/fig_layer.R#L116-L120), I use the palette from `dat$palette` as parameter from this [line](https://github.com/timelyportfolio/rBokeh/blob/fix/image-palette/R/fig_layer.R#L49)

but as I say it does work.  Also, I change `Spectral-10` to `Spectral10` to be an acceptable default palette.