### PR TITLE
Update layer_lines.R

### DIFF
--- a/R/layer_lines.R
+++ b/R/layer_lines.R
@@ -268,10 +268,10 @@ ly_abline <- function(
   }
 
   defer_fn <- function(data, xlim, ylim) {
-    if(length(data$x0[[1]]) == 1) {
+    if(length(data$x0) == 1) {
       if(data$x0 == "x0")
         return(data)
-    } else if(length(data$x0[[1]]) == 0) {
+    } else if(length(data$x0) == 0) {
       return(data)
     }
     # unlist because of json encoding issues


### PR DESCRIPTION
can't draw multiple vertical lines a time with function ly_abline

line 271: if(length(data$x0[[1]]) == 1) would be always true even if passed by a list/vector values of v. When I want to add a list of v values a time, the bug would cause error like:  "the condition has length > 1 and only the first element will be used"

z <- lm(dist ~ speed, data = cars)
p <- figure() %>%
  ly_points(cars, hover = cars) %>%
  ly_lines(lowess(cars), legend = "lowess") %>%
  **ly_abline(v=c(13,16), type = 2, width = 2)**
p 