### PR TITLE
Adds `with_outliers` to `ly_boxplot` to hide outliers.

### DIFF
--- a/R/layer_stats.R
+++ b/R/layer_stats.R
@@ -246,6 +246,8 @@ ly_quantile <- function(
 #' @param data an optional data frame, providing the source for x and y
 #' @param width with of each box, a value between 0 (no width) and 1 (full width)
 #' @param coef see \code{\link[grDevices]{boxplot.stats}}
+#' @param with_outliers \code{logical} indicating whether or not the outlier
+#'   points should be drawn outside of the whiskers of the boxplot.
 #' @template par-coloralpha
 #' @template par-lnamegroup
 #' @template dots-fillline
@@ -254,6 +256,7 @@ ly_quantile <- function(
 ly_boxplot <- function(
   fig, x, y = NULL, data = figure_data(fig),
   width = 0.9, coef = 1.5,
+  with_outliers = TRUE,
   color = "blue", alpha = 1,
   lname = NULL, lgroup = NULL, visible = TRUE,
   ...
@@ -362,16 +365,18 @@ ly_boxplot <- function(
       args$params[!fill_ind])
     )
 
-    if(length(bp$out) > 0) {
-      fig <- do.call(ly_points, c(
-        list(
-          fig = fig,
-          x = rep(gp, length(bp$out)), y = bp$out,
-          glyph = 1,
-          xlab = x_name, ylab = y_name
-        ),
-        args$params
-      ))
+    if (with_outliers) {
+      if(length(bp$out) > 0) {
+        fig <- do.call(ly_points, c(
+          list(
+            fig = fig,
+            x = rep(gp, length(bp$out)), y = bp$out,
+            glyph = 1,
+            xlab = x_name, ylab = y_name
+          ),
+          args$params
+        ))
+      }
     }
   }
 

--- a/man/ly_boxplot.Rd
+++ b/man/ly_boxplot.Rd
@@ -5,8 +5,8 @@
 \title{Add a "boxplot" layer to a Bokeh figure}
 \usage{
 ly_boxplot(fig, x, y = NULL, data = figure_data(fig), width = 0.9,
-  coef = 1.5, color = "blue", alpha = 1, lname = NULL, lgroup = NULL,
-  visible = TRUE, ...)
+  coef = 1.5, with_outliers = TRUE, color = "blue", alpha = 1,
+  lname = NULL, lgroup = NULL, visible = TRUE, ...)
 }
 \arguments{
 \item{fig}{figure to modify}
@@ -20,6 +20,9 @@ ly_boxplot(fig, x, y = NULL, data = figure_data(fig), width = 0.9,
 \item{width}{with of each box, a value between 0 (no width) and 1 (full width)}
 
 \item{coef}{see \code{\link[grDevices]{boxplot.stats}}}
+
+\item{with_outliers}{\code{logical} indicating whether or not the outlier
+points should be drawn outside of the whiskers of the boxplot.}
 
 \item{color}{color for the glyph - a hex code (with no alpha) or any of the 147 named CSS colors, e.g 'green', 'indigo' - for glyphs with both fill and line properties, see "Handling color" below}
 

--- a/man/sub_names.Rd
+++ b/man/sub_names.Rd
@@ -16,7 +16,7 @@ sub_names(fig, data, arg_obj, process_data_and_names = TRUE)
 \item{process_data_and_names}{boolean to determine if the data and x_name and y_name should be post processed}
 }
 \value{
-list of three groups: data, info, and params.
+list of three groups: data, info, and params
 }
 \description{
 Retrieve and properly parse all data


### PR DESCRIPTION
Users now can call `ly_boxplot` and opt to hide the outlier points, so we don't get double plotting when points are drawn over them.

This addresses issue #139

Compare the original:

```
figure(iris) %>% 
  ly_boxplot(x=Species, y=Petal.Length) %>% 
  ly_points(x=catjitter(Species), y=Petal.Length) 
```

vs

```
figure(iris) %>% 
  ly_boxplot(x=Species, y=Petal.Length, with_outliers=FALSE) %>% 
  ly_points(x=catjitter(Species), y=Petal.Length) 
```
