### PR TITLE
Fix minor typos in docs

### DIFF
--- a/R/fig_callback.R
+++ b/R/fig_callback.R
@@ -25,7 +25,7 @@ shiny_callback <- function(id) {
 
 #' Specify a console callback
 #'
-#' This registers a callback that simply prints the callback objects in the javascript console of your web browser.  A probalby more useful callback is the \code{\link{debug_callback}} which will place you inside a debugger in your web browser allowing you to inspect the callback objects.
+#' This registers a callback that simply prints the callback objects in the javascript console of your web browser.  A probably more useful callback is the \code{\link{debug_callback}} which will place you inside a debugger in your web browser allowing you to inspect the callback objects.
 #' @examples
 #' \donttest{
 #' figure() %>%
@@ -40,7 +40,7 @@ console_callback <- function() {
 
 #' Specify a custom callback
 #'
-#' This registers a callback that allows you to specify your own custom callback javascript code.  A probalby more useful callback to use in conjunction with this for working on the javascript code is the \code{\link{debug_callback}} which will place you inside a debugger in your web browser allowing you to inspect the callback objects.
+#' This registers a callback that allows you to specify your own custom callback javascript code.  A probably more useful callback to use in conjunction with this for working on the javascript code is the \code{\link{debug_callback}} which will place you inside a debugger in your web browser allowing you to inspect the callback objects.
 #' @param code a string of javascript callback code
 #' @param lnames vector of layer names to be made available inside the callback in addition to the default callback objects (see details)
 #' @param args named list of additional references to objects to be addressable in the callback

--- a/R/output_gist.R
+++ b/R/output_gist.R
@@ -2,7 +2,7 @@
 #'
 #' @param widget_string a string containing R code to create an htmlwidget
 #' @param name name of the gist
-#' @param created optional string for a "Created by" to preceed the README
+#' @param created optional string for a "Created by" to precede the README
 #' @param description optional text to go in README.md to describe the gist
 #' @param license license under which gist is released - one of those accepted here: \url{http://bl.ocks.org/licenses.txt}
 #' @param border should the bl.ocks.org iframe have a border?

--- a/man/console_callback.Rd
+++ b/man/console_callback.Rd
@@ -7,7 +7,7 @@
 console_callback()
 }
 \description{
-This registers a callback that simply prints the callback objects in the javascript console of your web browser.  A probalby more useful callback is the \code{\link{debug_callback}} which will place you inside a debugger in your web browser allowing you to inspect the callback objects.
+This registers a callback that simply prints the callback objects in the javascript console of your web browser.  A probably more useful callback is the \code{\link{debug_callback}} which will place you inside a debugger in your web browser allowing you to inspect the callback objects.
 }
 \examples{
 \donttest{

--- a/man/custom_callback.Rd
+++ b/man/custom_callback.Rd
@@ -14,7 +14,7 @@ custom_callback(code, lnames = NULL, args = NULL)
 \item{args}{named list of additional references to objects to be addressable in the callback}
 }
 \description{
-This registers a callback that allows you to specify your own custom callback javascript code.  A probalby more useful callback to use in conjunction with this for working on the javascript code is the \code{\link{debug_callback}} which will place you inside a debugger in your web browser allowing you to inspect the callback objects.
+This registers a callback that allows you to specify your own custom callback javascript code.  A probably more useful callback to use in conjunction with this for working on the javascript code is the \code{\link{debug_callback}} which will place you inside a debugger in your web browser allowing you to inspect the callback objects.
 }
 \details{
 If we add a layer and provide it, for example the \code{lname} "points", then if we refer to it using the \code{lnames} parameter to the callback, several objects will be made available inside the callback for you to access, given the names "points_data", "points_glyph", "points_glyph_rend", "points_hov_glyph", "points_ns_glyph", all pointers to different objects associated with the "points" layer that your callback can manipulate.

--- a/man/widget2gist.Rd
+++ b/man/widget2gist.Rd
@@ -16,7 +16,7 @@ widget2gist(widget_string, name, created = NULL, description = "",
 
 \item{name}{name of the gist}
 
-\item{created}{optional string for a "Created by" to preceed the README}
+\item{created}{optional string for a "Created by" to precede the README}
 
 \item{description}{optional text to go in README.md to describe the gist}
 


### PR DESCRIPTION
Thank you for this awesome package! I noticed some tiny mistakes in the documentation today. Please consider this PR to fix them.